### PR TITLE
chore: remove favicon configuration from example slides

### DIFF
--- a/example-rotation.md
+++ b/example-rotation.md
@@ -1,6 +1,5 @@
 ---
 theme: ./
-favicon: '/assets/favicon.svg'
 themeConfig:
   baseColor: 'rosewater'
   colorPattern: 'rotation'

--- a/example-single.md
+++ b/example-single.md
@@ -1,6 +1,5 @@
 ---
 theme: ./
-favicon: '/assets/favicon.svg'
 themeConfig:
   baseColor: 'sapphire'
   colorPattern: 'single'


### PR DESCRIPTION
## Summary
- Remove unnecessary favicon property from example slides
- Simplify example configuration to focus on theme-specific settings

## Test plan
- [x] Verify example-rotation.md loads without favicon configuration
- [x] Verify example-single.md loads without favicon configuration
- [x] Confirm no visual regression in example slides