### PR TITLE
fix: add optional chaining to safely access theme color properties

### DIFF
--- a/.changeset/early-ants-dress.md
+++ b/.changeset/early-ants-dress.md
@@ -1,0 +1,5 @@
+---
+'@ktym4a/slidev-theme-ktym4a': patch
+---
+
+add optional chaining to safely access theme color properties

--- a/composables/useColor.ts
+++ b/composables/useColor.ts
@@ -16,13 +16,13 @@ const useColor = () => {
 
   const baseColor = computed<Color>(
     () =>
-      ($slidev.themeConfigs?.baseColor.toString().toLowerCase() as Color) ||
+      ($slidev.themeConfigs?.baseColor?.toString().toLowerCase() as Color) ||
       COLORS[0],
   )
   const colorPattern = computed<Pattern>(
     () =>
       ($slidev.themeConfigs?.colorPattern
-        .toString()
+        ?.toString()
         .toLowerCase() as Pattern) || 'rotation',
   )
 


### PR DESCRIPTION
## Summary
- Add optional chaining operators to prevent runtime errors when accessing theme color configuration properties
- Ensure theme works correctly even when color configuration is not provided or partially defined
- Fix potential undefined errors in `useColor` composable
